### PR TITLE
Options to support splitting a rosbag file in duration and size chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ROS nodes that start/stop rosbag-record by a remote trigger
     <include file="console.machine"/>
 
     ... other console nodes ...
-    
+
     <node name="console-record" pkg="remote_rosbag_record" type="record" respawn="true">
       <rosparam file="console_topics.yml"/>
       <param name="prefix" value="console"/>
@@ -29,7 +29,7 @@ ROS nodes that start/stop rosbag-record by a remote trigger
       <param name="apped_date" value="true"/>
     </node>
   </group>
-  
+
 </launch>
 ```
 
@@ -94,6 +94,10 @@ See http://wiki.ros.org/rosbag/Commandline#record
 * ~buffer_size (int)
 * ~exclude_regex (string)
 * ~node (string)
+* ~split_duration (double)
+  * duration in seconds to record before splitting to a new bagfile
+* ~split_size (int)
+  * size in MB to record before splitting to a new bagfile
 
 ### trigger
 calls multiple start/stop services at once

--- a/src/record.cpp
+++ b/src/record.cpp
@@ -74,6 +74,22 @@ bool start(std_srvs::Empty::Request &, std_srvs::Empty::Response &) {
     }
   }
   rp::get("~node", options.node);
+  // Support automatic splitting of rosbag file in duration chunks
+  double duration = -1.0;
+  rp::get("~split_duration", duration);
+  if (duration > 0.0) {
+    options.split = true;
+    options.repeat_latched = true;
+    options.max_duration = ros::Duration(duration);
+  }
+  // Support automatic splitting of rosbag file in size chunks
+  int bagsize = 0;
+  rp::get("~split_size", bagsize);
+  if (bagsize > 0) {
+    options.split = true;
+    options.repeat_latched = true;
+    options.max_size = bagsize * 1048576;
+  }
   // note: this node aims to enable service-triggered logging.
   //       so does not support the following options that may autonomously stop logging
   //   trigger / snapshot / chunk_size / limit / split
@@ -146,7 +162,7 @@ int main(int argc, char *argv[]) {
   // manually free the recorder here.
   // the recorder contains a plugin loaded by class_loader so must be freed
   // before static variables in class_loader library (or get an exception).
-  // these static variables will be destroyed before the gloval variable recorder 
+  // these static variables will be destroyed before the gloval variable recorder
   // because they are allocated when the recorder is allocated in start().
   recorder.reset();
 


### PR DESCRIPTION
Thanks for this nice service-based utility for rosbag recording!
We really like using this in our robots which are often in the field and should record important information in certain states.

We would really like to have a split option though to make sure the recorded rosbag file is never going to be too big. Some of our usecases are robots that drive around for hours and sometimes even days. It's a shame if they stop because of a full disk, so ideally we split the recorded rosbags and clean up older ones once the disk is almost full.

Hence this PR